### PR TITLE
add mysql master-slave

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,0 +1,9 @@
+name: mysqlha
+version: 0.1.0
+description: MySQL cluster with a single master and zero or more slave repicas
+keywords:
+  - mysql
+  - database
+  - sql
+home: https://www.mysql.com/
+icon: https://www.mysql.com/common/logos/logo-mysql-170x115.png

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -1,17 +1,22 @@
-# MySQL
+# MySQL - Single Master, Multiple Slaves
 
-[Helm](https://helm.sh/) chart to deploy a multi-pod MySQL master-slave deployment [Kubernetes](http://kubernetes.io) cluster. Work was largely inspired by this [tutorial](https://kubernetes.io/docs/tutorials/stateful-application/run-replicated-stateful-application/).
+[MySQL](https://MySQL.org) is one of the most popular database servers in the world. Notable users include Wikipedia, Facebook and Google.
 
-## Usage
+## Introduction
 
-### Install 
+This chart bootstraps a single master and multiple slave MySQL deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. Largely inspired by this [tutorial](https://kubernetes.io/docs/tutorials/stateful-application/run-replicated-stateful-application/), further work was made to 'production-ize' the example.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
 ```bash
-$ git@github.com:jpoon/mysql-master-slave.git
-$ cd mysql-master-slave
-$ helm install --name my-release .
+$ helm install --name my-release incubator/mysqlha
 ```
 
 The command deploys MySQL cluster on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -43,3 +48,25 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `resources`                | CPU/Memory resource requests/limits | Memory: `128Mi`, CPU: `100m`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+## Persistence
+
+The [MySQL](https://hub.docker.com/_/mysql/) image stores the MySQL data and configurations at the `/var/lib/mysql` path of the container.
+
+By default persistence is enabled, and a PersistentVolumeClaim is created and mounted in that directory. As a result, a persistent volume will need to be defined:
+
+```
+# https://kubernetes.io/docs/user-guide/persistent-volumes/#azure-disk
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: fast
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Premium_LRS
+  location: westus
+```
+
+In order to disable this functionality you can change the values.yaml to disable persistence and use an emptyDir instead.

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -1,0 +1,45 @@
+# MySQL
+
+[Helm](https://helm.sh/) chart to deploy a multi-pod MySQL master-slave deployment [Kubernetes](http://kubernetes.io) cluster. Work was largely inspired by this [tutorial](https://kubernetes.io/docs/tutorials/stateful-application/run-replicated-stateful-application/).
+
+## Usage
+
+### Install 
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ git@github.com:jpoon/mysql-master-slave.git
+$ cd mysql-master-slave
+$ helm install --name my-release .
+```
+
+The command deploys MySQL cluster on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Uninstall
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the MySQL chart and their default values.
+
+| Parameter                  | Description                        | Default                                                    |
+| -----------------------    | ---------------------------------- | ---------------------------------------------------------- |
+| `imageTag`                 | `mysql` image tag.                 | Most recent release                                        |
+| `mysqlRootPassword`        | Password for the `root` user.      | `nil`                                                      |
+| `mysqlUser`                | Username of new user to create.    | `nil`                                                      |
+| `mysqlPassword`            | Password for the new user.         | Randomly generated                                         |
+| `mysqlReplicationUser`     | Username for replication user      | `repl`                                                     |
+| `mysqlReplicationPassword` | Password for replication user.     | Randomly generated                                         |
+| `persistence.enabled`      | Create a volume to store data      | true                                                       | 
+| `persistence.size`         | Size of persistent volume claim    | 10Gi                                                       |
+| `persistence.storageClass` | Type of persistent volume claim    | fast                                                       |
+| `persistence.accessMode`   | ReadWriteOnce or ReadOnly          | ReadWriteOnce                                              |
+| `resources`                | CPU/Memory resource requests/limits | Memory: `128Mi`, CPU: `100m`                              |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/incubator/mysqlha/templates/NOTES.txt
+++ b/incubator/mysqlha/templates/NOTES.txt
@@ -1,0 +1,19 @@
+The MySQL cluster is comprised of {{ .Values.replicaCount }} MySQL pods: 1 master and {{ sub .Values.replicaCount 1 }} slaves. Each instance is accessible within the cluster through: 
+
+    <pod-name>.{{ template "fullname" . }}
+
+`{{ template "fullname" . }}-0.{{ template "fullname" . }}` is designated as the master and where all writes should be executed against. Read queries can be executed against the `{{ template "fullname" . }}-readonly` service which distributes connections across all MySQL pods.
+
+To connect to your database:
+
+1. Obtain the root password: 
+
+    kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode; echo
+
+2. Run a pod to use as a client:
+
+    kubectl run mysql-client --image=mysql:{{ .Values.imageTag }} -it --rm --restart=Never -- /bin/sh
+
+2. Open a connection to one of the MySQL pods
+
+    mysql -h {{ template "fullname" . }}-0.{{ template "fullname" . }} -p

--- a/incubator/mysqlha/templates/_helpers.tpl
+++ b/incubator/mysqlha/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/mysqlha/templates/configmap.yaml
+++ b/incubator/mysqlha/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  master.cnf: |
+    # Apply this config only on the master.
+    [mysqld]
+    log-bin
+    skip_name_resolve
+  slave.cnf: |
+    # Apply this config only on slaves.
+    [mysqld]
+    super-read-only
+    skip_name_resolve
+  server-id.cnf: |
+    [mysqld]
+    server-id=@@SERVER_ID@@
+  create-replication-user.sql: |
+    CREATE USER IF NOT EXISTS '@@REPLICATION_USER@@' IDENTIFIED BY '@@REPLICATION_PASSWORD@@';
+    GRANT PROCESS, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO '@@REPLICATION_USER@@';
+    FLUSH PRIVILEGES;

--- a/incubator/mysqlha/templates/secret.yaml
+++ b/incubator/mysqlha/templates/secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.mysqlRootPassword }}
+  mysql-root-password:  {{ .Values.mysqlRootPassword | b64enc | quote }}
+  {{ else }}
+  mysql-root-password: {{ randAlphaNum 12 | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.mysqlUser }}
+  {{ if .Values.mysqlPassword }}
+  mysql-password: {{ .Values.mysqlPassword | b64enc | quote }}
+  {{ else }}
+  mysql-password: {{ randAlphaNum 12 | b64enc | quote }}
+  {{ end }}
+  {{ end }}
+  {{ if .Values.mysqlReplicationPassword }}
+  mysql-replication-password: {{ .Values.mysqlReplicationPassword | b64enc | quote }}
+  {{ else }}
+  mysql-replication-password: {{ randAlphaNum 12 | b64enc | quote }}
+  {{ end }}

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -1,0 +1,249 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  serviceName: {{ template "fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+            "name": "init-mysql",
+            "image": "mysql:{{ .Values.imageTag }}",
+            "command": ["bash", "-c", "
+              set -ex\n
+              # Generate mysql server-id from pod ordinal index.\n
+              [[ `hostname` =~ -([0-9]+)$ ]] || exit 1\n
+              ordinal=${BASH_REMATCH[1]}\n
+              # Copy server-id.conf adding offset to avoid reserved server-id=0 value.\n
+              cat /mnt/config-map/server-id.cnf | sed s/@@SERVER_ID@@/$((100 + $ordinal))/g > /mnt/conf.d/server-id.cnf\n
+              # Copy appropriate conf.d files from config-map to config mount.\n
+              if [[ $ordinal -eq 0 ]]; then\n
+                cp /mnt/config-map/master.cnf /mnt/conf.d/\n
+              else\n
+                cp /mnt/config-map/slave.cnf /mnt/conf.d/\n
+              fi\n
+              # Copy replication user script\n
+              if [[ $ordinal -eq 0 ]]; then\n
+                cp /mnt/config-map/create-replication-user.sql /mnt/scripts/create-replication-user.sql\n
+              fi\n
+            "],
+            "volumeMounts": [
+              {"name": "conf", "mountPath": "/mnt/conf.d"},
+              {"name": "config-map", "mountPath": "/mnt/config-map"},
+              {"name": "scripts", "mountPath": "/mnt/scripts"}
+             ]
+          },
+          {
+            "name": "clone-mysql",
+            "image": "gcr.io/google-samples/xtrabackup:1.0",
+            "command": ["bash", "-c", "
+              set -ex\n
+              # Skip the clone if data already exists.\n
+              [[ -d /var/lib/mysql/mysql ]] && exit 0\n
+              # Skip the clone on master (ordinal index 0).\n
+              [[ `hostname` =~ -([0-9]+)$ ]] || exit 1\n
+              ordinal=${BASH_REMATCH[1]}\n
+              [[ $ordinal -eq 0 ]] && exit 0\n
+              # Clone data from previous peer.\n
+              ncat --recv-only {{ template "fullname" . }}-$(($ordinal-1)).{{ template "fullname" . }} 3307 | xbstream -x -C /var/lib/mysql\n
+              # Prepare the backup.\n
+              xtrabackup --prepare --user=${MYSQL_REPLICATION_USER} --password=${MYSQL_REPLICATION_PASSWORD} --target-dir=/var/lib/mysql\n
+            "],
+            "env": [
+              {
+                "name": "MYSQL_REPLICATION_USER",
+                "value": "{{ .Values.mysqlReplicationUser }}"
+              },
+              {
+                "name": "MYSQL_REPLICATION_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "{{ template "fullname" . }}",
+                    "key": "mysql-replication-password"
+                  }
+                }
+              }
+            ],
+            "volumeMounts": [
+              {"name": "data", "mountPath": "/var/lib/mysql", "subPath": "mysql"},
+              {"name": "conf", "mountPath": "/etc/mysql/conf.d"}
+            ]
+          }
+        ]'
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:{{ .Values.imageTag }}
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: mysql-root-password
+        - name: MYSQL_REPLICATION_USER
+          value: {{ .Values.mysqlReplicationUser }}
+        - name: MYSQL_REPLICATION_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: mysql-replication-password
+        {{ if .Values.mysqlUser }}
+        - name: MYSQL_USER
+          value: {{ .Values.mysqlUser | quote }}
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: mysql-password
+        {{ end }}
+        ports:
+        - name: mysql
+          containerPort: 3306
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+          subPath: mysql
+        - name: conf
+          mountPath: /etc/mysql/conf.d
+        resources:
+          requests:
+            cpu: {{ .Values.resources.requests.cpu }}
+            memory: {{ .Values.resources.requests.memory }}
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - "-c"
+            - mysqladmin ping -h 127.0.0.1 -u root -p${MYSQL_ROOT_PASSWORD}
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            # Check we can execute queries over TCP (skip-networking is off).
+            command:
+            - /bin/sh
+            - "-c"
+            - MYSQL_PWD="${MYSQL_ROOT_PASSWORD}"
+            - mysql -h 127.0.0.1 -u root -e "SELECT 1"
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+      - name: xtrabackup
+        image: gcr.io/google-samples/xtrabackup:1.0
+        env:
+        - name: MYSQL_PWD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: mysql-root-password
+        - name: MYSQL_REPLICATION_USER
+          value: {{ .Values.mysqlReplicationUser }}
+        - name: MYSQL_REPLICATION_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: mysql-replication-password
+        ports:
+        - name: xtrabackup
+          containerPort: 3307
+        command:
+        - bash
+        - "-c"
+        - |
+          set -ex
+
+          echo "Waiting for mysqld to be ready (accepting connections)"
+          until mysql -h 127.0.0.1 -e "SELECT 1"; do sleep 1; done
+
+          # Create replication user
+          cd /mnt/scripts
+          if [[ -f create-replication-user.sql  ]]; then
+            cp create-replication-user.sql create-replication-user.orig.sql
+            cat create-replication-user.sql \
+              | sed s/@@REPLICATION_USER@@/"${MYSQL_REPLICATION_USER}"/g \
+              | sed s/@@REPLICATION_PASSWORD@@/"${MYSQL_REPLICATION_PASSWORD}"/g \
+              | tee create-replication-user.sql
+            mysql -h 127.0.0.1 --verbose < create-replication-user.sql
+          fi
+
+          cd /var/lib/mysql
+          # Determine binlog position of cloned data, if any.
+          if [[ -f xtrabackup_slave_info ]]; then
+            # XtraBackup already generated a partial "CHANGE MASTER TO" query
+            # because we're cloning from an existing slave.
+            cp xtrabackup_slave_info change_master_to.sql.in
+          elif [[ -f xtrabackup_binlog_info ]]; then
+            # We're cloning directly from master. Parse binlog position.
+            [[ $(cat xtrabackup_binlog_info) =~ ^(.*?)[[:space:]]+(.*?)$ ]] || exit 1
+            echo "CHANGE MASTER TO MASTER_LOG_FILE='${BASH_REMATCH[1]}',\
+                  MASTER_LOG_POS=${BASH_REMATCH[2]}" > change_master_to.sql.in
+          fi
+
+          # Check if we need to complete a clone by starting replication.
+          if [[ -f change_master_to.sql.in ]]; then
+
+            # In case of container restart, attempt this at-most-once.
+            cp change_master_to.sql.in change_master_to.sql.orig
+            mysql -h 127.0.0.1 --verbose<<EOF
+            $(<change_master_to.sql.orig),
+            MASTER_HOST='{{ template "fullname" . }}-0.{{ template "fullname" . }}',
+            MASTER_USER='${MYSQL_REPLICATION_USER}',
+            MASTER_PASSWORD='${MYSQL_REPLICATION_PASSWORD}',
+            MASTER_CONNECT_RETRY=10;
+            START SLAVE;
+          EOF
+          fi
+
+          # Start a server to send backups when requested by peers.
+          exec ncat --listen --keep-open --send-only --max-conns=1 3307 -c \
+            "xtrabackup --backup --slave-info --stream=xbstream --host=127.0.0.1 --user=${MYSQL_REPLICATION_USER} --password=${MYSQL_REPLICATION_PASSWORD}"
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+          subPath: mysql
+        - name: conf
+          mountPath: /etc/mysql/conf.d
+        - name: scripts
+          mountPath: /mnt/scripts
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      volumes:
+      - name: conf
+        emptyDir: {}
+      - name: config-map
+        configMap:
+          name: {{ template "fullname" . }}
+      - name: scripts
+        emptyDir: {}
+      {{- if eq .Values.persistence.enabled false }}
+      - name: data
+        emptyDir: {}
+      {{- end}}
+  volumeClaimTemplates:
+  {{- if .Values.persistence.enabled }}
+  - metadata:
+      name: data
+      annotations:
+        {{- if .Values.persistence.storageClass }}
+        volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass }}
+        {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+        {{- end }}
+    spec:
+      accessModes: 
+      - {{ .Values.persistence.accessMode | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/incubator/mysqlha/templates/svc.yaml
+++ b/incubator/mysqlha/templates/svc.yaml
@@ -1,0 +1,35 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+  - name: {{ template "fullname" . }}
+    port: 3306
+  clusterIP: None
+  selector:
+    app: {{ template "fullname" . }}
+---
+# Client service for connecting to any MySQL instance for reads.
+# For writes, you must instead connect to the master: mysql-0.mysql.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-readonly
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+  - name: {{ template "fullname" . }}
+    port: 3306
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/mysqlha/values.yaml
+++ b/incubator/mysqlha/values.yaml
@@ -1,0 +1,42 @@
+## mysql image version
+## ref: https://hub.docker.com/r/library/mysql/tags/
+##
+imageTag: "5.7.13"
+
+replicaCount: 3
+
+## Password for MySQL root user
+##
+# mysqlRootPassword: ## Default: random 10 character string
+
+## Username/password for MySQL replication user
+##
+mysqlReplicationUser: repl
+# mysqlReplicationPassword:
+
+## Create a database user
+##
+# mysqlUser:
+# mysqlPassword: ## Default: random 10 character string
+
+
+## Allow unauthenticated access, uncomment to enable
+##
+# mysqlAllowEmptyPassword: true
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  storageClass: fast 
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
Helm chart to deploy a multi-pod MySQL master-slave deployment Kubernetes cluster. Largely inspired by this [tutorial](https://kubernetes.io/docs/tutorials/stateful-application/run-replicated-stateful-application/), this chart also adds creation and usage of a replication user. 