### PR TITLE
Fixing a couple issues with the spark chart and adding an external LB…

### DIFF
--- a/incubator/cassandra/templates/svc.yaml
+++ b/incubator/cassandra/templates/svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "fullname" . }}
+  namespace: cassandra
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -12,6 +13,6 @@ spec:
   ports:
   - name: {{ template "fullname" . }}
     port: 9042
-  clusterIP: None
   selector:
     app: {{ template "fullname" . }}
+  type: "LoadBalancer"

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -11,7 +11,7 @@ Master:
   ImagePullPolicy: "Always"
   ServicePort: 7077
   ContainerPort: 7077
-  EnableHA: true
+  EnableHA: false
   Resources:
     Requests:
       Cpu: "700m"
@@ -33,7 +33,7 @@ WebUi:
 Worker:
   Name: worker
   Image: "erikschlegel/spark-worker"
-  ImageTag: "2.2.0-ha"
+  ImageTag: "2.2.0"
   ImagePullPolicy: "Always"
   Replicas: 6
   Component: "spark-worker"


### PR DESCRIPTION
I need the cassandra cluster exposed externally so I can run cassandra cql queries within our zeppelin notebooks. 