### PR TITLE
Fix: Invoke SparkSubmitCommand with postStart hook.

### DIFF
--- a/stable/spark/templates/spark-master-deployment.yaml
+++ b/stable/spark/templates/spark-master-deployment.yaml
@@ -27,11 +27,14 @@ spec:
           imagePullPolicy: "{{.Values.Master.ImagePullPolicy}}"
           image: "{{.Values.Master.Image}}:{{.Values.Master.ImageTag}}"
           {{- if .Values.Master.SparkSubmitCommand }}
-          command:
-          - "/bin/sh"
-          - "-c"
-          - |
-            {{.Values.Master.SparkSubmitCommand}}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - |
+                    {{.Values.Master.SparkSubmitCommand}}
           {{- end }}
           ports:
             - containerPort: {{.Values.Master.ContainerPort}}


### PR DESCRIPTION
Previously, we were overriding the command from the base Spark master image.