### PR TITLE
Spark Worker Distributed ConfigMap

### DIFF
--- a/stable/spark/templates/spark-worker-statefulset.yaml
+++ b/stable/spark/templates/spark-worker-statefulset.yaml
@@ -27,6 +27,11 @@ spec:
           image: "{{.Values.Worker.Image}}:{{.Values.Worker.ImageTag}}"
           imagePullPolicy: "{{.Values.Worker.ImagePullPolicy}}"
           command: ["/start-worker"]
+          {{- if .Values.Worker.ConfigMapName }}
+          envFrom:
+          - configMapRef:
+              name: "{{.Values.Worker.ConfigMapName}}"
+          {{ else }}
       #    command: ["/opt/spark/bin/spark-class", "org.apache.spark.deploy.worker.Worker", "spark://{{ template "master-fullname" . }}:{{.Values.Master.ServicePort}}", "--webui-port", "{{.Values.Worker.ContainerPort}}", "--work-dir", "{{.Values.Worker.WorkingDirectory}}"]
           ports:
             - containerPort: {{.Values.Worker.ContainerPort}}

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -41,6 +41,7 @@ Worker:
   Component: "spark-worker"
   WorkingDirectory: "/opt/spark/work"
   ContainerPort: 8081
+  #ConfigMapName: spark-master-conf
   Resources:
     Requests:
       Cpu: "700m"


### PR DESCRIPTION
… now be able to either have seperate configmaps for workers and master, or reuse masters config map across all workers. For Fortis, we want to reuse the same config map across the entire spark cluster.