### PR TITLE
Fault Domain Aware / Data Center aware base image

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 name: cassandra
 home: http://cassandra.apache.org
-version: 0.1.0
+version: 0.1.3
 description: A highly scalable, high-performance distributed database designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure.
 icon: http://cassandra.apache.org/img/cassandra_logo.png
 sources:

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -73,10 +73,6 @@ spec:
             value: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}-0.{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}.{{.Release.Namespace}}.svc.cluster.local"
           - name: CASSANDRA_CLUSTER_NAME
             value: "{{.Values.cassandra.ClusterName}}"
-          - name: CASSANDRA_DC
-            value: "{{.Values.cassandra.DC}}"
-          - name: CASSANDRA_RACK
-            value: "{{.Values.cassandra.Rack}}"
           - name: CASSANDRA_AUTO_BOOTSTRAP
             value: "{{.Values.cassandra.AutoBootstrap}}"
           - name: POD_IP

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -5,10 +5,10 @@
 
 Name: cassandra
 Component: "cassandra"
-replicaCount: 6
-Image: "erikschlegel/cassandra"
-VmInstanceType: "Standard_L4s"
-ImageTag: "v12"
+replicaCount: 3
+Image: "xtoph/azcassandra"
+VmInstanceType: "Standard_DS4_v2"
+ImageTag: "v2"
 ImagePullPolicy: "Always"
 
 # Cassandra configuration options
@@ -18,8 +18,6 @@ cassandra:
   MaxHeapSize: "4000M"
   HeapNewSize: "100M"
   ClusterName: "cassandra"
-  DC: "dc-eastus2-cassandra"
-  Rack: "rack-eastus2-cassandra"
   AutoBootstrap: "false"
 
 # Persistence information

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -6,9 +6,9 @@
 Name: cassandra
 Component: "cassandra"
 replicaCount: 3
-Image: "xtoph/azcassandra"
+Image: "xtoph/azure-cassandra"
 VmInstanceType: "Standard_DS4_v2"
-ImageTag: "v2"
+ImageTag: "v12"
 ImagePullPolicy: "Always"
 
 # Cassandra configuration options


### PR DESCRIPTION
switched base image that configures Cassandra datacenter and rack from Azure metadata service. 

Details, Scripts and Dockerfiles about the customization available at: https://github.com/xtophs/azure-fault-domain-on-dcos-nodes